### PR TITLE
Update for Hapi 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "chai-as-promised": "^4.1.1",
-    "hapi": "^8.0.0",
+    "hapi": "^9.0.0",
     "istanbul": "^0.3.2",
     "mocha": "^2.0.1"
   },
   "peerDependencies": {
-    "hapi": "^8.0.0"
+    "hapi": ">=8.0.0"
   },
   "dependencies": {
     "bluebird": "^2.3.11"


### PR DESCRIPTION
# Problem
As mentioned in #5, hapi 9.x.x has been released. Though there are no compatibility issues between this package and hapi 9, the `peerDependency` in *package.json* is set to `^8.0.0`. This prevents npm from installing this package in hapi 9 is already installed in the user's project.

# Solution
All tests pass using hapi 9.x.x, and the [release notes](https://github.com/hapijs/hapi/issues/2682) indicate that there were no changes to the `plugins` API.  **Just change the version of hapi used for tests, and the peer dependency to allow hapi 8 and 9. 